### PR TITLE
Incorporate destroy-circular logic. Fixes #2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,55 @@
 'use strict';
-module.exports = function (err) {
-	var ret = {
-		name: err.name
-	};
 
-	Object.getOwnPropertyNames(err).forEach(function (key) {
-		ret[key] = err[key];
+// Make a value ready for JSON.stringify() / process.send()
+module.exports = function serializeError(value) {
+	if (typeof value === 'object') {
+		return destroyCircular(value, []);
+	}
+
+	// People sometimes throw things besides Error objects, so...
+
+	if (typeof value === 'function') {
+		// JSON.stringify discards functions. We do to, unless a function is thrown directly.
+		return '[Function: ' + (value.name || 'anonymous') + ']';
+	}
+
+	return value;
+};
+
+// https://www.npmjs.com/package/destroy-circular
+function destroyCircular(from, seen) {
+	var to;
+	if (Array.isArray(from)) {
+		to = [];
+	} else {
+		to = {};
+		if (typeof from.name === 'string') {
+			// name is not enumerable on Error objects.
+			to.name = from.name;
+		}
+	}
+
+	seen.push(from);
+
+	Object.getOwnPropertyNames(from).forEach(function (key) {
+		var value = from[key];
+
+		if (typeof value === 'function') {
+			return;
+		}
+
+		if (!value || typeof value !== 'object') {
+			to[key] = value;
+			return;
+		}
+
+		if (seen.indexOf(from[key]) === -1) {
+			to[key] = destroyCircular(from[key], seen.slice(0));
+			return;
+		}
+
+		to[key] = '[Circular]';
 	});
 
-	// these gets added on native errors in Node.js for some reason
-	if (ret.type === undefined) {
-		delete ret.type;
-	}
-
-	if (ret.arguments === undefined) {
-		delete ret.arguments;
-	}
-
-	return ret;
-};
+	return to;
+}

--- a/test.js
+++ b/test.js
@@ -1,10 +1,102 @@
 import test from 'ava';
-import fn from './';
+import serialize from './';
 
 test(t => {
-	const x = Object.keys(fn(new Error('foo')));
-	t.true(x.includes('name'));
-	t.true(x.includes('stack'));
-	t.true(x.includes('message'));
+	const serialized = serialize(new Error('foo'));
+	const x = Object.keys(serialized);
+	t.not(x.indexOf('name'), -1);
+	t.not(x.indexOf('stack'), -1);
+	t.not(x.indexOf('message'), -1);
+	t.end();
+});
+
+test('should destroy circular references', t => {
+	const obj = {};
+	obj.child = {parent: obj};
+
+	const serialized = serialize(obj);
+
+	t.is(typeof serialized, 'object');
+	t.is(serialized.child.parent, '[Circular]');
+	t.end();
+});
+
+test('should not affect the original object', t => {
+	const obj = {};
+	obj.child = {parent: obj};
+
+	const serialized = serialize(obj);
+
+	t.not(serialized, obj);
+	t.is(obj.child.parent, obj);
+	t.end();
+});
+
+test('should only destroy parent references', t => {
+	const obj = {};
+	const common = {thing: obj};
+	obj.one = {firstThing: common};
+	obj.two = {secondThing: common};
+
+	const serialized = serialize(obj);
+
+	t.is(typeof serialized.one.firstThing, 'object');
+	t.is(typeof serialized.two.secondThing, 'object');
+	t.is(serialized.one.firstThing.thing, '[Circular]');
+	t.is(serialized.two.secondThing.thing, '[Circular]');
+	t.end();
+});
+
+test('should work on arrays', t => {
+	const obj = {};
+	const common = [obj];
+	const x = [common];
+	const y = [['test'], common];
+	y[0][1] = y;
+	obj.a = {x: x};
+	obj.b = {y: y};
+
+	const serialized = serialize(obj);
+
+	t.true(Array.isArray(serialized.a.x));
+	t.is(serialized.a.x[0][0], '[Circular]');
+	t.is(serialized.b.y[0][0], 'test');
+	t.is(serialized.b.y[1][0], '[Circular]');
+	t.is(serialized.b.y[0][1], '[Circular]');
+	t.end();
+});
+
+test('should discard nested functions', t => {
+	function a() {}
+	function b() {}
+	a.b = b;
+	const obj = {a: a};
+
+	const serialized = serialize(obj);
+
+	t.same(serialized, {});
+	t.end();
+});
+
+test('should replace top-level functions with a helpful string', t => {
+	function a() {}
+	function b() {}
+	a.b = b;
+
+	const serialized = serialize(a);
+
+	t.is(serialized, '[Function: a]');
+	t.end();
+});
+
+test('should drop functions', t => {
+	function a() {}
+	a.foo = 'bar;';
+	a.b = a;
+	const obj = {a: a};
+
+	const serialized = serialize(obj);
+	t.same(serialized, {});
+	t.false(serialized.hasOwnProperty('a'));
 	t.end();
 });


### PR DESCRIPTION
For serialized AssertionErrors, it is possible that the `actual`
and `expected` properties contain circular references, causing
a thrown Error when you serialize the result with JSON.stringify().

This destroys circular references on the copied Object. Replacing
them with a string (`[Circular]`).

Also, `JSON.stringify(function() {})` returns `undefined`, and
will drop any functions that are attached to an object it is serializing.
This mimics the latter behavior, but if a function is passed in as the top
level argument, it returns a string (`[Function: fnName]`). Since
the most common use for this is to transmit thrown values for logging,
it makes sense to provide this helpful String instead of `undefined`.
(All this despite the fact it is a terrible idea to throw a function).

Based on:
  https://github.com/jonpacker/destroy-circular/pull/1

Fixes: #2