### PR TITLE
skip non-enumerable properties in destroyCircular. Fixes #5

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,17 @@
 // Make a value ready for JSON.stringify() / process.send()
 module.exports = function serializeError(value) {
 	if (typeof value === 'object') {
-		return destroyCircular(value, []);
+		var serialized = destroyCircular(value, []);
+		if (typeof value.name === 'string') {
+			serialized.name = value.name;
+		}
+		if (typeof value.message === 'string') {
+			serialized.message = value.message;
+		}
+		if (typeof value.stack === 'string') {
+			serialized.stack = value.stack;
+		}
+		return serialized;
 	}
 
 	// People sometimes throw things besides Error objects, so...
@@ -23,15 +33,11 @@ function destroyCircular(from, seen) {
 		to = [];
 	} else {
 		to = {};
-		if (typeof from.name === 'string') {
-			// name is not enumerable on Error objects.
-			to.name = from.name;
-		}
 	}
 
 	seen.push(from);
 
-	Object.getOwnPropertyNames(from).forEach(function (key) {
+	Object.keys(from).forEach(function (key) {
 		var value = from[key];
 
 		if (typeof value === 'function') {

--- a/test.js
+++ b/test.js
@@ -86,3 +86,16 @@ test('should drop functions', t => {
 	t.same(serialized, {});
 	t.false(serialized.hasOwnProperty('a'));
 });
+
+test('should not access deep non-enumerable properties', t => {
+	const error = Error('some error');
+	const obj = {};
+	Object.defineProperty(obj, 'someProp', {
+		enumerable: false,
+		get: () => {
+			throw Error('some other error');
+		}
+	});
+	error.obj = obj;
+	t.notThrows(() => serialize(error));
+});


### PR DESCRIPTION
I've implemented the discussed fix for issue #5, that is, replacing `Object.getOwnPropertyNames` with `Object.keys` and manually grabbing `message`, `stack`, and `name` from the original error object.