### PR TITLE
Support errors with error properties - fixes #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Make a value ready for JSON.stringify() / process.send()
-module.exports = function serializeError(value) {
+function serializeError(value) {
 	if (typeof value === 'object') {
 		return destroyCircular(value, []);
 	}
@@ -14,7 +14,9 @@ module.exports = function serializeError(value) {
 	}
 
 	return value;
-};
+}
+
+module.exports = serializeError;
 
 // https://www.npmjs.com/package/destroy-circular
 function destroyCircular(from, seen) {

--- a/index.js
+++ b/index.js
@@ -3,21 +3,7 @@
 // Make a value ready for JSON.stringify() / process.send()
 module.exports = function serializeError(value) {
 	if (typeof value === 'object') {
-		var serialized = destroyCircular(value, []);
-
-		if (typeof value.name === 'string') {
-			serialized.name = value.name;
-		}
-
-		if (typeof value.message === 'string') {
-			serialized.message = value.message;
-		}
-
-		if (typeof value.stack === 'string') {
-			serialized.stack = value.stack;
-		}
-
-		return serialized;
+		return destroyCircular(value, []);
 	}
 
 	// People sometimes throw things besides Error objects, so...
@@ -60,6 +46,18 @@ function destroyCircular(from, seen) {
 
 		to[key] = '[Circular]';
 	});
+
+	if (typeof from.name === 'string') {
+		to.name = from.name;
+	}
+
+	if (typeof from.message === 'string') {
+		to.message = from.message;
+	}
+
+	if (typeof from.stack === 'string') {
+		to.stack = from.stack;
+	}
 
 	return to;
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   ],
   "devDependencies": {
     "ava": "*",
-    "xo": "*"
+    "xo": "^0.16.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -99,3 +99,12 @@ test('should not access deep non-enumerable properties', t => {
 	error.obj = obj;
 	t.notThrows(() => serialize(error));
 });
+
+test('should serialize nested errors', t => {
+	const error = Error('outer error');
+	error.innerError = Error('inner error');
+
+	const serialized = serialize(error);
+	t.is(serialized.message, 'outer error');
+	t.is(serialized.innerError.message, 'inner error');
+});

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ test('should drop functions', t => {
 
 	const serialized = serialize(obj);
 	t.deepEqual(serialized, {});
-	t.false(serialized.hasOwnProperty('a'));
+	t.false(Object.hasOwnProperty.call(serialized, 'a'));
 });
 
 test('should not access deep non-enumerable properties', t => {
@@ -93,7 +93,7 @@ test('should not access deep non-enumerable properties', t => {
 	Object.defineProperty(obj, 'someProp', {
 		enumerable: false,
 		get: () => {
-			throw Error('some other error');
+			throw new Error('some other error');
 		}
 	});
 	error.obj = obj;


### PR DESCRIPTION
I moved the section where it grabs `message`, `stack`, and `name` inside of the recursive `destroyCircular` method, so that if any nested properties are errors they'll be serialized properly as well.