### PR TITLE
Add serialization of the `.code` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function destroyCircular(from, seen) {
 
 		to[key] = '[Circular]';
 	}
-	
+
 	if (typeof from.name === 'string') {
 		to.name = from.name;
 	}
@@ -52,7 +52,7 @@ function destroyCircular(from, seen) {
 	if (typeof from.stack === 'string') {
 		to.stack = from.stack;
 	}
-	
+
 	if (typeof from.code === 'string') {
 		to.code = from.code;
 	}

--- a/index.js
+++ b/index.js
@@ -41,21 +41,11 @@ function destroyCircular(from, seen) {
 		to[key] = '[Circular]';
 	}
 
-	if (typeof from.name === 'string') {
-		to.name = from.name;
-	}
-
-	if (typeof from.message === 'string') {
-		to.message = from.message;
-	}
-
-	if (typeof from.stack === 'string') {
-		to.stack = from.stack;
-	}
-
-	if (typeof from.code === 'string') {
-		to.code = from.code;
-	}
+	['name', 'message', 'stack', 'code'].forEach(prop => {
+		if (typeof from[prop] === 'string') {
+			to[prop] = from[prop];
+		}
+	});
 
 	return to;
 }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function destroyCircular(from, seen) {
 
 		to[key] = '[Circular]';
 	}
-
+	
 	if (typeof from.name === 'string') {
 		to.name = from.name;
 	}
@@ -51,6 +51,10 @@ function destroyCircular(from, seen) {
 
 	if (typeof from.stack === 'string') {
 		to.stack = from.stack;
+	}
+	
+	if (typeof from.code === 'string') {
+		to.code = from.code;
 	}
 
 	return to;

--- a/test.js
+++ b/test.js
@@ -88,7 +88,7 @@ test('should drop functions', t => {
 });
 
 test('should not access deep non-enumerable properties', t => {
-	const error = Error('some error');
+	const error = new Error('some error');
 	const obj = {};
 	Object.defineProperty(obj, 'someProp', {
 		enumerable: false,


### PR DESCRIPTION
I noted `code` isn't being serialized.

This is an error from `got`

```
console.log(serializeError(err))
console.log('code is', err.code)
```

output: 

```
{ input: 'aiosjdioajd',
  name: 'TypeError [ERR_INVALID_URL]',
  message: 'Invalid URL: aiosjdioajd',
  stack: 'TypeError [ERR_INVALID_URL]: Invalid URL…'
}

code is ERR_INVALID_URL
```