### PR TITLE
Handle top-level null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const destroyCircular = (from, seen) => {
 };
 
 const serializeError = value => {
-	if (typeof value === 'object') {
+	if (value !== null && typeof value === 'object') {
 		return destroyCircular(value, []);
 	}
 

--- a/test.js
+++ b/test.js
@@ -108,3 +108,8 @@ test('should serialize nested errors', t => {
 	t.is(serialized.message, 'outer error');
 	t.is(serialized.innerError.message, 'inner error');
 });
+
+test('should handle top-level null values', t => {
+	const serialized = serializeError(null);
+	t.is(serialized, null);
+});


### PR DESCRIPTION
Hi @sindresorhus,

I hope it's fine to submit a pull request without a corresponding issue.

This pull request fixes the problem that `serializeError()` can't currently be called with a null value. In other words `serializeError(null)` will throw a "Cannot convert undefined or null to object"-error.

Of course it doesn't really make sense to have null as an error but unfortunately null gets sometimes thrown instead of an error object. A workaround which would work already is to use a ternary expression to guard the call to `serializeError()` like this: `(error === null) ? null : serializeError(error)`. But since the library already contains code to handle other edge cases I thought it's fine to add another 14 characters to handle this one as well.

Please let me know if you want me to change this pull request in any way.