### PR TITLE
Preserve properties of type Date in the serialized error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare const serializeError: {
 	console.log(serializeError(error));
 	//=> {name: 'Error', message: '🦄', stack: 'Error: 🦄\n    at Object.<anonymous> …'}
 
-	// including Date properties
+	// Including Date properties
 	error.time = new Date(0);
 	console.log(serializeError(error));
 	//=> {name: 'Error', message: '🦄', time: 1970-01-01T00:00:00.000Z, stack: 'Error: 🦄\n    at Object.<anonymous> …'}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,11 @@ declare const serializeError: {
 
 	console.log(serializeError(error));
 	//=> {name: 'Error', message: '🦄', stack: 'Error: 🦄\n    at Object.<anonymous> …'}
+
+	// including Date properties
+	error.time = new Date(0);
+	console.log(serializeError(error));
+	//=> {name: 'Error', message: '🦄', time: 1970-01-01T00:00:00.000Z, stack: 'Error: 🦄\n    at Object.<anonymous> …'}
 	```
 	*/
 	<ErrorType>(error: ErrorType): ErrorType extends Primitive

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const destroyCircular = (from, seen) => {
 			to[key] = value;
 			continue;
 		}
-		
+
 		if (value instanceof Date) {
 			to[key] = value.toISOString();
 			continue;

--- a/index.js
+++ b/index.js
@@ -10,13 +10,8 @@ const destroyCircular = (from, seen) => {
 			continue;
 		}
 
-		if (!value || typeof value !== 'object') {
+		if (!value || typeof value !== 'object' || value instanceof Date) {
 			to[key] = value;
-			continue;
-		}
-
-		if (value instanceof Date) {
-			to[key] = value.toISOString();
 			continue;
 		}
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ const destroyCircular = (from, seen) => {
 			to[key] = value;
 			continue;
 		}
+		
+		if (value instanceof Date) {
+			to[key] = value.toISOString();
+			continue;
+		}
 
 		if (!seen.includes(from[key])) {
 			to[key] = destroyCircular(from[key], seen.slice());

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"send"
 	],
 	"dependencies": {
-		"type-fest": "^0.3.0"
+		"type-fest": "^0.3.1"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,11 @@ console.log(error);
 
 console.log(serializeError(error));
 //=> {name: 'Error', message: '🦄', stack: 'Error: 🦄\n    at Object.<anonymous> …'}
+
+// including Date properties
+error.time = new Date(0);
+console.log(serializeError(error));
+//=> {name: 'Error', message: '🦄', time: 1970-01-01T00:00:00.000Z, stack: 'Error: 🦄\n    at Object.<anonymous> …'}
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ console.log(error);
 console.log(serializeError(error));
 //=> {name: 'Error', message: '🦄', stack: 'Error: 🦄\n    at Object.<anonymous> …'}
 
-// including Date properties
+// Including Date properties
 error.time = new Date(0);
 console.log(serializeError(error));
 //=> {name: 'Error', message: '🦄', time: 1970-01-01T00:00:00.000Z, stack: 'Error: 🦄\n    at Object.<anonymous> …'}

--- a/test.js
+++ b/test.js
@@ -111,7 +111,7 @@ test('should serialize nested errors', t => {
 
 test('should convert properties of type Date to ISO string', t => {
 	const error = new Error('foo');
-	const date = new Date(0)
+	const date = new Date(0);
 	error.date = date;
 	const serialized = serializeError(error);
 	t.is(serialized.date, date.toISOString());

--- a/test.js
+++ b/test.js
@@ -108,3 +108,10 @@ test('should serialize nested errors', t => {
 	t.is(serialized.message, 'outer error');
 	t.is(serialized.innerError.message, 'inner error');
 });
+
+test('should convert Date to ISO string', t => {
+	const error = new Error('foo');
+	error.birthdate = new Date(0);
+	const serialized = serializeError(error);
+	t.is(serialized.birthdate, '1970-01-01T00:00:00.000Z');
+});

--- a/test.js
+++ b/test.js
@@ -109,9 +109,10 @@ test('should serialize nested errors', t => {
 	t.is(serialized.innerError.message, 'inner error');
 });
 
-test('should convert Date to ISO string', t => {
+test('should convert properties of type Date to ISO string', t => {
 	const error = new Error('foo');
-	error.birthdate = new Date(0);
+	const date = new Date(0)
+	error.date = date;
 	const serialized = serializeError(error);
-	t.deepEqual(serialized.birthdate, new Date(0));
+	t.is(serialized.date, date.toISOString());
 });

--- a/test.js
+++ b/test.js
@@ -113,5 +113,5 @@ test('should convert Date to ISO string', t => {
 	const error = new Error('foo');
 	error.birthdate = new Date(0);
 	const serialized = serializeError(error);
-	t.is(serialized.birthdate, '1970-01-01T00:00:00.000Z');
+	t.deepEqual(serialized.birthdate, new Date(0));
 });


### PR DESCRIPTION
Some errors carry Date objects. E.g. about the end of the validity period of a [JSON Web Token](https://github.com/auth0/node-jsonwebtoken/blob/master/lib/TokenExpiredError.js)