### PR TITLE
Converts Buffers to strings by default or arrays if default is overridden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "serialize-error",
-	"version": "6.0.0",
-	"description": "Serialize/deserialize an error into a plain object",
-	"license": "MIT",
-	"repository": "sindresorhus/serialize-error",
-	"funding": "https://github.com/sponsors/sindresorhus",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "https://sindresorhus.com"
-	},
-	"engines": {
-		"node": ">=10"
-	},
-	"scripts": {
-		"test": "xo && ava && tsd"
-	},
-	"files": [
-		"index.js",
-		"index.d.ts"
-	],
-	"keywords": [
-		"error",
-		"serialize",
-		"stringify",
-		"object",
-		"convert",
-		"process",
-		"send",
-		"deserialize"
-	],
-	"dependencies": {
-		"type-fest": "^0.12.0"
-	},
-	"devDependencies": {
-		"ava": "^2.4.0",
-		"tsd": "^0.11.0",
-		"xo": "^0.24.0"
-	}
+  "name": "serialize-error",
+  "version": "6.0.0",
+  "description": "Serialize/deserialize an error into a plain object",
+  "license": "MIT",
+  "repository": "sindresorhus/serialize-error",
+  "funding": "https://github.com/sponsors/sindresorhus",
+  "author": {
+	"name": "Sindre Sorhus",
+	"email": "sindresorhus@gmail.com",
+	"url": "https://sindresorhus.com"
+  },
+  "engines": {
+	"node": ">=10"
+  },
+  "scripts": {
+	"test": "xo && ava && tsd"
+  },
+  "files": [
+	"index.js",
+	"index.d.ts"
+  ],
+  "keywords": [
+	"error",
+	"serialize",
+	"stringify",
+	"object",
+	"convert",
+	"process",
+	"send",
+	"deserialize"
+  ],
+  "dependencies": {
+	"type-fest": "^0.12.0"
+  },
+  "devDependencies": {
+	"ava": "^2.4.0",
+	"tsd": "^0.11.0",
+	"xo": "^0.24.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Serialize/deserialize an error into a plain object
 
-Useful if you for example need to `JSON.stringify()` or `process.send()` the error.
+Useful if you for example need to `JSON.stringify()` or `process.send()` the error.  This library works in the browser and Node.js
 
 ## Install
 
@@ -13,7 +13,9 @@ $ npm install serialize-error
 ## Usage
 
 ```js
-const {serializeError, deserializeError} = require('serialize-error');
+const {serialize, deserialize} = require('serialize-error');
+const serializeError = serialize({});
+const deserializeError = deserialize({});
 
 const error = new Error('🦄');
 
@@ -27,6 +29,37 @@ console.log(serialized);
 
 const deserialized = deserializeError(serialized);
 //=> [Error: 🦄]
+```
+
+## Browser Use
+Use a <a href="https://github.com/feross/buffer">polyfill for `Buffer`</a>.
+## Options
+By default Buffers are not converted to strings.
+
+To configure Buffers to be converted to strings:
+```js
+const {serialize, deserialize} = require('serialize-error');
+const serializeError = serialize({ serializeError: { buffer: { toString: true } } } );
+const deserializeError = deserialize({});
+
+const err = new Error('🦄');
+err.buffer = Buffer.from('ABC', 'utf8');
+
+console.log(serializeError(err).buffer);
+//=>  [ 65, 66, 67 ]
+```
+
+If you wish to override the UTF-8 encoding, use one of the encodings supported by Buffer.toString ('hex', 'base64', 'latin1', etc.)
+```js
+const {serialize, deserialize} = require('serialize-error');
+const serializeError = serialize({ serializeError: { buffer: { toStringEncoding: 'hex' } } });
+const deserializeError = deserialize({});
+
+const err = new Error('🦄');
+err.buffer = Buffer.from('ABC', 'utf8');
+
+console.log(serializeError(err).buffer);
+//=>  0daa
 ```
 
 ## API


### PR DESCRIPTION
This PR solve problems with the serialization of Buffers.  For example, a Buffer representing the string 'ABC' (e.g., `Buffer.from('ABC', 'utf8')` ) is serialized as: `{ "0": 65, "1": 66, "2": 67 ]`.  This PR instead serializes it by default as 'ABC'.  The default can also be overridden to serialize it as an array: `[65, 66, 67]`.  The array is more useful than the current implementation because it can be easily converted into a string by the user.

The PR sets up an optional `options` parameter to be able to override defaults.