### PR TITLE
fix SyntaxError in NonError

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ class NonError extends Error {
 	static _prepareSuperMessage(message) {
 		try {
 			return JSON.stringify(message);
-		} catch {
+		} catch (err) {
 			return String(message);
 		}
 	}


### PR DESCRIPTION
While rare, some browsers will throw a `SyntaxError` when there is no parameters after `catch`:

![image](https://user-images.githubusercontent.com/1935258/115074935-10425e00-9e96-11eb-9cbe-272ad75c04da.png)

If I were to prettify the error, it lands here (this is column 39295 :laughing:)
```js
                static _prepareSuperMessage(t) {
                    try {
                        return JSON.stringify(t)
                    } catch {
                            ^ SyntaxError: Unexpected token {
                        return String(t)
                    }
                }
```

This is basically just a problem in older browsers, but surprisingly there's still enough people out there using old browsers that I get hit with this once or twice a day.  Shouldn't really hurt anything to have a parameter that isn't used, though, unless it's a linting problem.

Great library, btw.