### PR TITLE
Handle streams attached to an error by replacing them with `'[object Stream]'`

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ const destroyCircular = ({
 		}
 
 		// TODO: Use `stream.isReadable()` when targeting Node.js 18.
-		if (typeof value === 'object' && typeof value._read === 'function' && typeof value._readableState === 'object') {
-			to[key] = '[object Readable]';
+		if (typeof value === 'object' && typeof value.pipe === 'function') {
+			to[key] = '[object Stream]';
 			continue;
 		}
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,11 @@ const destroyCircular = ({
 			continue;
 		}
 
+		if (typeof value === 'object' && typeof value._read === 'function' && typeof value._readableState === 'object') {
+			to[key] = '[object Readable]';
+			continue;
+		}
+
 		if (typeof value === 'function') {
 			continue;
 		}

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ const destroyCircular = ({
 			continue;
 		}
 
+		// TODO: Use `stream.isReadable()` when targeting Node.js 18.
 		if (typeof value === 'object' && typeof value._read === 'function' && typeof value._readableState === 'object') {
 			to[key] = '[object Readable]';
 			continue;

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import Stream from 'node:stream';
 import test from 'ava';
 import {serializeError, deserializeError} from './index.js';
 
@@ -80,6 +81,15 @@ test('should discard buffers', t => {
 	const object = {a: Buffer.alloc(1)};
 	const serialized = serializeError(object);
 	t.deepEqual(serialized, {a: '[object Buffer]'});
+});
+
+test('should discard streams', t => {
+	t.deepEqual(serializeError({s: new Stream.Stream()}), {s: '[object Stream]'}, 'Stream.Stream');
+	t.deepEqual(serializeError({s: new Stream.Readable()}), {s: '[object Stream]'}, 'Stream.Readable');
+	t.deepEqual(serializeError({s: new Stream.Writable()}), {s: '[object Stream]'}, 'Stream.Writable');
+	t.deepEqual(serializeError({s: new Stream.Duplex()}), {s: '[object Stream]'}, 'Stream.Duplex');
+	t.deepEqual(serializeError({s: new Stream.Transform()}), {s: '[object Stream]'}, 'Stream.Transform');
+	t.deepEqual(serializeError({s: new Stream.PassThrough()}), {s: '[object Stream]'}, 'Stream.PassThrough');
 });
 
 test('should replace top-level functions with a helpful string', t => {


### PR DESCRIPTION
fixes https://github.com/sindresorhus/serialize-error/issues/56

![image](https://user-images.githubusercontent.com/385731/151702830-23fde5ae-87bc-47d7-a521-57e53427297e.png)
