### PR TITLE
Drop unnecessary `captureStackTrace` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,6 @@ export class NonError extends Error {
 			configurable: true,
 			writable: true,
 		});
-
-		if (Error.captureStackTrace) {
-			Error.captureStackTrace(this, NonError);
-		}
 	}
 
 	static _prepareSuperMessage(message) {


### PR DESCRIPTION
I'm not sure I understand this call. NonError extends `Error`, which already captures the stack natively:

```js
❯ node
Welcome to Node.js v16.4.2.
Type ".help" for more information.

> new class NonError extends Error {name='NonError'}
NonError
    at REPL1:1:1
    at Script.runInThisContext (node:vm:129:12)
    at REPLServer.defaultEval (node:repl:522:29)
    at bound (node:domain:416:15)
    at REPLServer.runBound [as eval] (node:domain:427:12)
    at REPLServer.onLine (node:repl:849:10)
    at REPLServer.emit (node:events:406:35)
    at REPLServer.emit (node:domain:470:12)
    at REPLServer.Interface._onLine (node:readline:487:10)
    at REPLServer.Interface._line (node:readline:852:8)
```