### PR TITLE
Use public instance class field for `name` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ export class NonError extends Error {
 
 	constructor(message) {
 		super(NonError._prepareSuperMessage(message));
-  }
+	}
 
 	static _prepareSuperMessage(message) {
 		try {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,8 @@
 export class NonError extends Error {
+	name = 'NonError';
+
 	constructor(message) {
 		super(NonError._prepareSuperMessage(message));
-
-		Object.defineProperty(this, 'name', {
-			value: 'NonError',
-			configurable: true,
-			writable: true,
-		});
 
 		if (Error.captureStackTrace) {
 			Error.captureStackTrace(this, NonError);


### PR DESCRIPTION
It seems to be supported in Node 12

https://node.green/#ES2022-features-instance-class-fields-public-instance-class-fields