### PR TITLE
Add `isErrorLike()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
 
 @example
-```js
+```
 import {isErrorLike} from 'serialize-error';
 
 const error = new Error('🦄');

--- a/index.d.ts
+++ b/index.d.ts
@@ -124,4 +124,4 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 /**
 Predicate to determine whether an object looks like an error, even if it's not an instance of Error
 */
-export function isSerializedError(error: unknown): error is ErrorObject;
+export function isErrorLike(error: unknown): error is ErrorObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,5 +130,33 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 
 /**
 Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
+
+```js
+import {isErrorLike} from 'serialize-error';
+
+const error = new Error('🦄');
+error.one = {two: {three: {}}};
+
+isErrorLike({
+	name: 'DOMException',
+	message: 'It happened',
+	stack: 'at foo (index.js:2:9)',
+});
+//=> true
+
+isErrorLike(new Error('🦄'));
+//=> true
+
+isErrorLike(serializeError(new Error('🦄'));
+//=> true
+
+isErrorLike({
+	name: 'Bluberricious pancakes',
+	stack: 12,
+	ingredients: 'Blueberry',
+});
+//=> false
+```
+
 */
 export function isErrorLike(value: unknown): value is ErrorLike;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,14 +5,17 @@ export type ErrorObject = {
 	stack?: string;
 	message?: string;
 	code?: string;
+	cause?: unknown;
 } & JsonObject;
 
 export type ErrorLike = {
+	[key: string]: unknown;
 	name: string;
 	stack: string;
 	message: string;
 	code?: string;
-} & JsonObject;
+	cause?: unknown;
+};
 
 export interface Options {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,6 +131,7 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 /**
 Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
 
+@example
 ```js
 import {isErrorLike} from 'serialize-error';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,13 @@ export type ErrorObject = {
 	code?: string;
 } & JsonObject;
 
+export type ErrorLike = {
+	name: string;
+	stack: string;
+	message: string;
+	code?: string;
+} & JsonObject;
+
 export interface Options {
 	/**
 	The maximum depth of properties to preserve when serializing/deserializing.

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,4 +131,4 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 /**
 Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
 */
-export function isErrorLike(value: unknown): value is ErrorObject;
+export function isErrorLike(value: unknown): value is ErrorLike;

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,6 @@ console.log(error);
 export function deserializeError(errorObject: ErrorObject | unknown, options?: Options): Error;
 
 /**
-Predicate to determine whether an object looks like an error, even if it's not an instance of Error
+Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
 */
-export function isErrorLike(error: unknown): error is ErrorObject;
+export function isErrorLike(value: unknown): value is ErrorObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,3 +120,8 @@ console.log(error);
 ```
 */
 export function deserializeError(errorObject: ErrorObject | unknown, options?: Options): Error;
+
+/**
+Predicate to determine whether an object looks like an error, even if it's not an instance of Error
+*/
+export function isSerializedError(error: unknown): error is ErrorObject;

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ export function deserializeError(value, options = {}) {
 	return new NonError(value);
 }
 
-export function isSerializedError(error) {
+export function isErrorLike(error) {
 	return error
 	&& typeof error === 'object'
 	&& 'name' in error

--- a/index.js
+++ b/index.js
@@ -161,3 +161,11 @@ export function deserializeError(value, options = {}) {
 
 	return new NonError(value);
 }
+
+export function isSerializedError(error) {
+	return error
+	&& typeof error === 'object'
+	&& 'name' in error
+	&& 'message' in error
+	&& 'stack' in error;
+}

--- a/index.js
+++ b/index.js
@@ -162,10 +162,10 @@ export function deserializeError(value, options = {}) {
 	return new NonError(value);
 }
 
-export function isErrorLike(error) {
-	return error
-	&& typeof error === 'object'
-	&& 'name' in error
-	&& 'message' in error
-	&& 'stack' in error;
+export function isErrorLike(value) {
+	return value
+	&& typeof value === 'object'
+	&& 'name' in value
+	&& 'message' in value
+	&& 'stack' in value;
 }

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ export function serializeError(value, options = {}) {
 	// People sometimes throw things besides Error objects…
 	if (typeof value === 'function') {
 		// `JSON.stringify()` discards functions. We do too, unless a function is thrown directly.
-		return `[Function: ${(value.name || 'anonymous')}]`;
+		return `[Function: ${value.name || 'anonymous'}]`;
 	}
 
 	return value;

--- a/readme.md
+++ b/readme.md
@@ -122,3 +122,34 @@ console.log(serializeError(error, {maxDepth: 1}));
 console.log(serializeError(error, {maxDepth: 2}));
 //=> {name: 'Error', message: '…', one: { two: {}}}
 ```
+
+### isErrorLike(value)
+
+Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
+
+```js
+import {isErrorLike} from 'serialize-error';
+
+const error = new Error('🦄');
+error.one = {two: {three: {}}};
+
+isErrorLike({
+	name: "DOMException",
+	message: "It happened",
+	stack: "at foo (index.js:2:9)",
+})
+//=> true
+
+isErrorLike(new Error('🦄'))
+//=> true
+
+isErrorLike(serializeError(new Error('🦄'))
+//=> true
+
+isErrorLike({
+	name: 'Bluberricious pancakes',
+	stack: 12,
+	ingredients: 'Blueberry',
+})
+//=> false
+```

--- a/readme.md
+++ b/readme.md
@@ -134,9 +134,9 @@ const error = new Error('🦄');
 error.one = {two: {three: {}}};
 
 isErrorLike({
-	name: "DOMException",
-	message: "It happened",
-	stack: "at foo (index.js:2:9)",
+	name: 'DOMException',
+	message: 'It happened',
+	stack: 'at foo (index.js:2:9)',
 });
 //=> true
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ const error = new Error('🦄');
 console.log(error);
 //=> [Error: 🦄]
 
-const serialized = serializeError(error)
+const serialized = serializeError(error);
 
 console.log(serialized);
 //=> {name: 'Error', message: '🦄', stack: 'Error: 🦄\n    at Object.<anonymous> …'}
@@ -137,19 +137,19 @@ isErrorLike({
 	name: "DOMException",
 	message: "It happened",
 	stack: "at foo (index.js:2:9)",
-})
+});
 //=> true
 
-isErrorLike(new Error('🦄'))
+isErrorLike(new Error('🦄'));
 //=> true
 
-isErrorLike(serializeError(new Error('🦄'))
+isErrorLike(serializeError(new Error('🦄'));
 //=> true
 
 isErrorLike({
 	name: 'Bluberricious pancakes',
 	stack: 12,
 	ingredients: 'Blueberry',
-})
+});
 //=> false
 ```

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
-import {serializeError, deserializeError} from './index.js';
+import {serializeError, deserializeError, isSerializedError} from './index.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);
@@ -382,4 +382,15 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 
 	const levelThree = serializeError(error, {maxDepth: 3});
 	t.deepEqual(levelThree, {message, name, stack, one: {two: {three: {}}}});
+});
+
+test('should identify serialized errors', t => {
+	t.true(isSerializedError(serializeError(new Error('I\'m missing more than just your body'))));
+	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
+	t.true(isSerializedError(serializeError(new Error())));
+	t.true(isSerializedError({
+		name: 'Error',
+		message: 'Is it too late now to say sorry',
+		stack: 'at <anonymous>:3:14',
+	}));
 });

--- a/test.js
+++ b/test.js
@@ -385,12 +385,24 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 });
 
 test('should identify serialized errors', t => {
-	t.true(isErrorLike(serializeError(new Error('I\'m missing more than just your body'))));
+	t.true(isErrorLike(serializeError(new Error('I’m missing more than just your body'))));
 	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
 	t.true(isErrorLike(serializeError(new Error())));
 	t.true(isErrorLike({
 		name: 'Error',
 		message: 'Is it too late now to say sorry',
 		stack: 'at <anonymous>:3:14',
+	}));
+
+	t.false(isErrorLike({
+		name: 'Bluberricious pancakes',
+		stack: 12,
+		ingredients: 'Blueberry',
+	}));
+
+	t.false(isErrorLike({
+		name: 'Edwin Monton',
+		message: 'I’ve been trying to contact you about extended warranty',
+		medium: 'Glass bottle in ocean',
 	}));
 });

--- a/test.js
+++ b/test.js
@@ -402,7 +402,7 @@ test('should identify serialized errors', t => {
 
 	t.false(isErrorLike({
 		name: 'Edwin Monton',
-		message: 'I’ve been trying to contact you about extended warranty',
+		message: 'We’ve been trying to reach you about your car’s extended warranty',
 		medium: 'Glass bottle in ocean',
 	}));
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
-import {serializeError, deserializeError, isSerializedError} from './index.js';
+import {serializeError, deserializeError, isErrorLike} from './index.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);
@@ -385,10 +385,10 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 });
 
 test('should identify serialized errors', t => {
-	t.true(isSerializedError(serializeError(new Error('I\'m missing more than just your body'))));
+	t.true(isErrorLike(serializeError(new Error('I\'m missing more than just your body'))));
 	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
-	t.true(isSerializedError(serializeError(new Error())));
-	t.true(isSerializedError({
+	t.true(isErrorLike(serializeError(new Error())));
+	t.true(isErrorLike({
 		name: 'Error',
 		message: 'Is it too late now to say sorry',
 		stack: 'at <anonymous>:3:14',


### PR DESCRIPTION
Closes #47 

Since `deserializeError` also accepts `Error` instances, I decided to do the same for this detector.

Names:

- isErrorLike: it matches the "array-like" nomenclature, which also is `true` or real arrays
- isSerializedError: can't use it because the function also matches regular `Error` instances
- isErrorObject: it matches the `ErrorObject` type, but it reads like "is `Error` object", as in "is `Error` instance. 

Unrelated suggestions:
- rename the `ErrorObject` type to `ErrorLike`
- make `name`, `message` and `stack` properties of this type mandatory, because they always exist in `new Error()` and its serialized counterpart 