### PR TITLE
Preserve error constructor

### DIFF
--- a/error-constructors.d.ts
+++ b/error-constructors.d.ts
@@ -1,0 +1,3 @@
+const errorConstructors: Map<string, ErrorConstructor>;
+
+export default errorConstructors;

--- a/error-constructors.d.ts
+++ b/error-constructors.d.ts
@@ -1,5 +1,7 @@
 /**
 Map of error constructors to recreate from the serialize `name` property. If the name is not found in this map, the errors will be deserialized as simple `Error` instances.
+
+Warning: Only simple and standard error constructors are supported, like `new MyCustomError(name)`. If your error constructor *requires* a second parameter or does not accept a string as first parameter, adding it to this map *will* break the deserialization.
 */
 declare const errorConstructors: Map<string, ErrorConstructor>;
 

--- a/error-constructors.d.ts
+++ b/error-constructors.d.ts
@@ -1,6 +1,6 @@
 /**
 Map of error constructors to recreate from the serialize `name` property. If the name is not found in this map, the errors will be deserialized as simple `Error` instances.
 */
-const errorConstructors: Map<string, ErrorConstructor>;
+declare const errorConstructors: Map<string, ErrorConstructor>;
 
 export default errorConstructors;

--- a/error-constructors.d.ts
+++ b/error-constructors.d.ts
@@ -1,3 +1,6 @@
+/**
+Map of error constructors to recreate from the serialize `name` property. If the name is not found in this map, the errors will be deserialized as simple `Error` instances.
+*/
 const errorConstructors: Map<string, ErrorConstructor>;
 
 export default errorConstructors;

--- a/error-constructors.js
+++ b/error-constructors.js
@@ -7,7 +7,7 @@ const list = [
 	TypeError,
 	URIError,
 
-	// Browser-specific errors
+	// Built-in errors
 	globalThis.DOMException,
 
 	// Node-specific errors

--- a/error-constructors.js
+++ b/error-constructors.js
@@ -1,0 +1,25 @@
+const list = [
+	// Native ES errors https://262.ecma-international.org/12.0/#sec-well-known-intrinsic-objects
+	EvalError,
+	RangeError,
+	ReferenceError,
+	SyntaxError,
+	TypeError,
+	URIError,
+
+	// Browser-specific errors
+	globalThis.DOMException,
+
+	// Node-specific errors
+	// https://nodejs.org/api/errors.html
+	globalThis.AssertionError,
+	globalThis.SystemError,
+]
+	.filter(Boolean)
+	.map(
+		constructor => [constructor.name, constructor],
+	);
+
+const errorConstructors = new Map(list);
+
+export default errorConstructors;

--- a/error-constructors.js
+++ b/error-constructors.js
@@ -15,6 +15,7 @@ const list = [
 	globalThis.AssertionError,
 	globalThis.SystemError,
 ]
+	// Non-native Errors are used with `globalThis` because they might be missing. This filter drops them when undefined.
 	.filter(Boolean)
 	.map(
 		constructor => [constructor.name, constructor],

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,6 @@ console.log(error);
 export function deserializeError(errorObject: ErrorObject | unknown, options?: Options): Error;
 
 /**
-Predicate to determine whether an object looks like an error, even if it's not an instance of Error
+Predicate to determine whether an object looks like an error, even if it's not an instance of Error.
 */
 export function isErrorLike(error: unknown): error is ErrorObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,34 @@ console.log(error);
 export function deserializeError(errorObject: ErrorObject | unknown, options?: Options): Error;
 
 /**
-Predicate to determine whether an object looks like an error, even if it's not an instance of Error.
+Predicate to determine whether a value looks like an error, even if it's not an instance of `Error`. It must have at least the `name`, `message`, and `stack` properties.
+
+@example
+```
+import {isErrorLike} from 'serialize-error';
+
+const error = new Error('🦄');
+error.one = {two: {three: {}}};
+
+isErrorLike({
+name: 'DOMException',
+message: 'It happened',
+stack: 'at foo (index.js:2:9)',
+});
+//=> true
+
+isErrorLike(new Error('🦄'));
+//=> true
+
+isErrorLike(serializeError(new Error('🦄'));
+//=> true
+
+isErrorLike({
+name: 'Bluberricious pancakes',
+stack: 12,
+ingredients: 'Blueberry',
+});
+//=> false
+```
 */
-export function isErrorLike(error: unknown): error is ErrorObject;
+export function isErrorLike(value: unknown): value is ErrorObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -124,4 +124,4 @@ export function deserializeError(errorObject: ErrorObject | unknown, options?: O
 /**
 Predicate to determine whether an object looks like an error, even if it's not an instance of Error
 */
-export function isSerializedError(error: unknown): error is ErrorObject;
+export function isErrorLike(error: unknown): error is ErrorObject;

--- a/index.d.ts
+++ b/index.d.ts
@@ -146,9 +146,9 @@ const error = new Error('🦄');
 error.one = {two: {three: {}}};
 
 isErrorLike({
-name: 'DOMException',
-message: 'It happened',
-stack: 'at foo (index.js:2:9)',
+	name: 'DOMException',
+	message: 'It happened',
+	stack: 'at foo (index.js:2:9)',
 });
 //=> true
 
@@ -159,11 +159,11 @@ isErrorLike(serializeError(new Error('🦄'));
 //=> true
 
 isErrorLike({
-name: 'Bluberricious pancakes',
-stack: 12,
-ingredients: 'Blueberry',
+	name: 'Bluberricious pancakes',
+	stack: 12,
+	ingredients: 'Blueberry',
 });
 //=> false
 ```
 */
-export function isErrorLike(value: unknown): value is ErrorObject;
+export function isErrorLike(value: unknown): value is ErrorLike;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 import {Primitive, JsonObject} from 'type-fest';
 
+export {default as errorConstructors} from './error-constructors.js';
+
 export type ErrorObject = {
 	name?: string;
 	message?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,3 +120,8 @@ console.log(error);
 ```
 */
 export function deserializeError(errorObject: ErrorObject | unknown, options?: Options): Error;
+
+/**
+Predicate to determine whether an object looks like an error, even if it's not an instance of Error
+*/
+export function isSerializedError(error: unknown): error is ErrorObject;

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ export function deserializeError(value, options = {}) {
 	return new NonError(value);
 }
 
-export function isSerializedError(error) {
+export function isErrorLike(error) {
 	return error
 	&& typeof error === 'object'
 	&& 'name' in error

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const toJSON = from => {
 	return json;
 };
 
-const getErrorConstructor = name => nativeErrorConstructors.get(name) ?? Error;
+const getErrorConstructor = name => nativeErrorConstructors.get(name) || Error;
 
 const destroyCircular = ({
 	from,

--- a/index.js
+++ b/index.js
@@ -161,3 +161,11 @@ export function deserializeError(value, options = {}) {
 
 	return new NonError(value);
 }
+
+export function isSerializedError(error) {
+	return error
+	&& typeof error === 'object'
+	&& 'name' in error
+	&& 'message' in error
+	&& 'stack' in error;
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import nativeErrorConstructors from './error-constructors.js';
+import errorConstructors from './error-constructors.js';
 
 export class NonError extends Error {
 	name = 'NonError';
@@ -48,7 +48,7 @@ const toJSON = from => {
 	return json;
 };
 
-const getErrorConstructor = name => nativeErrorConstructors.get(name) || Error;
+const getErrorConstructor = name => errorConstructors.get(name) || Error;
 
 // eslint-disable-next-line complexity
 const destroyCircular = ({
@@ -186,3 +186,5 @@ export function isErrorLike(error) {
 	&& 'message' in error
 	&& 'stack' in error;
 }
+
+export {errorConstructors};

--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ const destroyCircular = ({
 }) => {
 	const to = to_ || (Array.isArray(from) ? [] : {});
 
-	console.log({to});
 	seen.push(from);
 
 	if (depth >= maxDepth) {

--- a/index.js
+++ b/index.js
@@ -179,12 +179,12 @@ export function deserializeError(value, options = {}) {
 	return new NonError(value);
 }
 
-export function isErrorLike(error) {
-	return error
-	&& typeof error === 'object'
-	&& 'name' in error
-	&& 'message' in error
-	&& 'stack' in error;
+export function isErrorLike(value) {
+	return value
+	&& typeof value === 'object'
+	&& 'name' in value
+	&& 'message' in value
+	&& 'stack' in value;
 }
 
 export {errorConstructors};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
 	},
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"error-constructors.js",
+		"error-constructors.d.ts"
 	],
 	"keywords": [
 		"error",

--- a/readme.md
+++ b/readme.md
@@ -58,11 +58,13 @@ console.log(unknown);
 The [list of known errors](./error-constructors.js) can be extended globally. This also works if `serialize-error` is a sub-dependency that's not used directly.
 
 ```js
-import {AxiosError} from 'axios'
 import {errorConstructors} from 'serialize-error';
+import {MyCustomError} from './errors.js'
 
-errorConstructors.set('AxiosError', AxiosError)
+errorConstructors.set('MyCustomError', MyCustomError)
 ```
+
+**Warning:** Only simple and standard error constructors are supported, like `new MyCustomError(name)`. If your error constructor **requires** a second parameter or does not accept a string as first parameter, adding it to this map **will** break the deserialization.
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,39 @@ console.log(deserialized);
 //=> [Error: 🦄]
 ```
 
+### Error constructors
+
+When a serialized error with a known `name` is encountered, it will be deserialized using the corresponding error constructor, while enknown error names will be deserialized as regular errors:
+
+```js
+import {deserializeError} from 'serialize-error';
+
+const known = deserializeError({
+	name: 'TypeError',
+	message: '🦄'
+});
+
+console.log(known);
+//=> [TypeError: 🦄] <-- still a TypeError
+
+const unknown = deserializeError({
+	name: 'TooManyCooksError',
+	message: '🦄'
+});
+
+console.log(unknown);
+//=> [Error: 🦄] <-- just a regular Error
+```
+
+The [list of known errors](./error-constructors.js) can be extended globally. This also works if `serialize-error` is a sub-dependency that's not used directly.
+
+```js
+import {AxiosError} from 'axios'
+import {errorConstructors} from 'serialize-error';
+
+errorConstructors.set('AxiosError', AxiosError)
+```
+
 ## API
 
 ### serializeError(value, options?)
@@ -93,6 +126,7 @@ Deserialize a plain object or any value into an `Error` object.
 - Non-enumerable properties are kept non-enumerable (name, message, stack, cause).
 - Enumerable properties are kept enumerable (all properties besides the non-enumerable ones).
 - Circular references are handled.
+- [Native error constructors](./error-constructors.js) are preserved (TypeError, DOMException, etc) and [more can be added.](#error-constructors)
 
 ### options
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
-import {serializeError, deserializeError} from './index.js';
+import {serializeError, deserializeError, isSerializedError} from './index.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);
@@ -382,4 +382,15 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 
 	const levelThree = serializeError(error, {maxDepth: 3});
 	t.deepEqual(levelThree, {message, name, stack, one: {two: {three: {}}}});
+});
+
+test('should identify serialized errors', t => {
+	t.true(isSerializedError(serializeError(new Error('I\'m missing more than just your body'))));
+	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
+	t.true(isSerializedError(serializeError(new Error())));
+	t.true(isSerializedError({
+		name: 'Error',
+		message: 'Is it too late now to say sorry',
+		stack: 'at <anonymous>:3:14',
+	}));
 });

--- a/test.js
+++ b/test.js
@@ -200,6 +200,28 @@ test('should deserialize plain object', t => {
 	t.is(deserialized.code, 'code');
 });
 
+test('should deserialize nested errors', t => {
+	const object = {
+		message: 'error message',
+		stack: 'at <anonymous>:1:13',
+		name: 'name',
+		code: 'code',
+		innerError: {
+			message: 'source error message',
+			stack: 'at <anonymous>:3:14',
+			name: 'name',
+			code: 'code',
+		},
+	};
+
+	const {innerError} = deserializeError(object);
+	t.true(innerError instanceof Error);
+	t.is(innerError.message, 'source error message');
+	t.is(innerError.stack, 'at <anonymous>:3:14');
+	t.is(innerError.name, 'name');
+	t.is(innerError.code, 'code');
+});
+
 test('should deserialize the cause property', t => {
 	const object = {
 		message: 'error message',
@@ -215,6 +237,7 @@ test('should deserialize the cause property', t => {
 	};
 
 	const {cause} = deserializeError(object);
+	t.true(cause instanceof Error);
 	t.is(cause.message, 'source error message');
 	t.is(cause.stack, 'at <anonymous>:3:14');
 	t.is(cause.name, 'name');

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
 import {serializeError, deserializeError, isErrorLike} from './index.js';
+import errorConstructors from './error-constructors.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);
@@ -183,6 +184,17 @@ test('should deserialize and preserve existing properties', t => {
 	t.is(deserialized.message, 'foo');
 	t.true(deserialized.customProperty);
 });
+
+for (const [name, CustomError] of errorConstructors) {
+	test(`should deserialize and preserve the ${name} constructor`, t => {
+		const deserialized = deserializeError({
+			name,
+			message: 'foo',
+		});
+		t.true(deserialized instanceof CustomError);
+		t.is(deserialized.message, 'foo');
+	});
+}
 
 test('should deserialize plain object', t => {
 	const object = {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
-import {serializeError, deserializeError, isSerializedError} from './index.js';
+import {serializeError, deserializeError, isErrorLike} from './index.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);
@@ -385,10 +385,10 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 });
 
 test('should identify serialized errors', t => {
-	t.true(isSerializedError(serializeError(new Error('I\'m missing more than just your body'))));
+	t.true(isErrorLike(serializeError(new Error('I\'m missing more than just your body'))));
 	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
-	t.true(isSerializedError(serializeError(new Error())));
-	t.true(isSerializedError({
+	t.true(isErrorLike(serializeError(new Error())));
+	t.true(isErrorLike({
 		name: 'Error',
 		message: 'Is it too late now to say sorry',
 		stack: 'at <anonymous>:3:14',

--- a/test.js
+++ b/test.js
@@ -428,12 +428,24 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 });
 
 test('should identify serialized errors', t => {
-	t.true(isErrorLike(serializeError(new Error('I\'m missing more than just your body'))));
+	t.true(isErrorLike(serializeError(new Error('I’m missing more than just your body'))));
 	// eslint-disable-next-line unicorn/error-message -- Testing this eventuality
 	t.true(isErrorLike(serializeError(new Error())));
 	t.true(isErrorLike({
 		name: 'Error',
 		message: 'Is it too late now to say sorry',
 		stack: 'at <anonymous>:3:14',
+	}));
+
+	t.false(isErrorLike({
+		name: 'Bluberricious pancakes',
+		stack: 12,
+		ingredients: 'Blueberry',
+	}));
+
+	t.false(isErrorLike({
+		name: 'Edwin Monton',
+		message: 'We’ve been trying to reach you about your car’s extended warranty',
+		medium: 'Glass bottle in ocean',
 	}));
 });

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 import {Buffer} from 'node:buffer';
 import Stream from 'node:stream';
 import test from 'ava';
-import {serializeError, deserializeError, isErrorLike} from './index.js';
 import errorConstructors from './error-constructors.js';
+import {serializeError, deserializeError, isErrorLike} from './index.js';
 
 function deserializeNonError(t, value) {
 	const deserialized = deserializeError(value);


### PR DESCRIPTION
<details>
<summary>Previous notes about native-only support</summary>

Partially fix for #48. 

Includes and is blocked by #69 

Custom constructors will need extra logic, because what happens when `CustomError`’s signature **requires** a second parameter? 

- Deserialization should catch that and use a regular Error, and/or
- The user should pass `.set(MyError, object => new MyError(object.message, object.otherProp))`

But this might require further bikeshedding, so I'm leaving it out of this PR

</details>

Fixes #48