### PR TITLE
Remove direct usage of Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,8 @@ const destroyCircular = ({
 	});
 
 	for (const [key, value] of Object.entries(from)) {
-		// eslint-disable-next-line node/prefer-global/buffer
-		if (typeof Buffer === 'function' && Buffer.isBuffer(value)) {
+		if (value !== null && value.constructor !== null &&
+			typeof value.constructor.isBuffer === 'function' && value.constructor.isBuffer(value)) {
 			to[key] = '[object Buffer]';
 			continue;
 		}

--- a/index.js
+++ b/index.js
@@ -93,8 +93,7 @@ const destroyCircular = ({
 	});
 
 	for (const [key, value] of Object.entries(from)) {
-		if (value !== null && value.constructor !== null &&
-			typeof value.constructor.isBuffer === 'function' && value.constructor.isBuffer(value)) {
+		if (value && value instanceof Uint8Array && value.constructor.name === 'Buffer') {
 			to[key] = '[object Buffer]';
 			continue;
 		}


### PR DESCRIPTION
Updates the logic to verify if the object is a Buffer when removing circular references, avoiding direct usage of the Buffer class

resolves #93