### PR TITLE
Remove JSON.stringify from usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Serialize/deserialize an error into a plain object
 
-Useful if you for example need to `JSON.stringify()` or `process.send()` the error.
+Useful if you for example need to `process.send()` the error.
 
 ## Install
 


### PR DESCRIPTION
The output is not JSON.stringify safe, see discussion in #55

I noticed this myself when trying to pass a [`got`](https://github.com/sindresorhus/got) error to this - it causes JSON.stringify to fail