### PR TITLE
Revert "Remove JSON.stringify from usage"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Serialize/deserialize an error into a plain object
 
-Useful if you for example need to `process.send()` the error.
+Useful if you for example need to `JSON.stringify()` or `process.send()` the error.
 
 ## Install
 


### PR DESCRIPTION
Reverts sindresorhus/serialize-error#97

`JSON.stringify(serializeError(new Error('hi')))` is perfectly fine, and so is most such usage. `serialize-error` only fails on complex objects/errors/types, for which full serializers might be more useful. The removed line in the readme did not suggest full compatibility with it.

A similar limitation is also already specified:

https://github.com/sindresorhus/serialize-error/blob/a2df3aeea73e39482eeb7d2fe445ac7120231593/readme.md#L67

