### PR TITLE
Require Node.js 18+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 18
           - 20
-          - 22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
+          - 18
+          - 20
+          - 22
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {Primitive, JsonObject} from 'type-fest';
+import {type Primitive, type JsonObject} from 'type-fest';
 
 export {default as errorConstructors} from './error-constructors.js';
 
@@ -19,7 +19,7 @@ export type ErrorLike = {
 	code?: string;
 };
 
-export interface Options {
+export type Options = {
 	/**
 	The maximum depth of properties to preserve when serializing/deserializing.
 
@@ -47,7 +47,7 @@ export interface Options {
 	@default true
 	*/
 	readonly useToJSON?: boolean;
-}
+};
 
 /**
 Serialize an `Error` object into a plain object.

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ const destroyCircular = ({
 	}
 
 	for (const {property, enumerable} of commonProperties) {
-		if (typeof from[property] !== 'undefined' && from[property] !== null) {
+		if (from[property] !== undefined && from[property] !== null) {
 			Object.defineProperty(to, property, {
 				value: isErrorLike(from[property]) ? continueDestroyCircular(from[property]) : from[property],
 				enumerable: forceEnumerable ? true : enumerable,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,7 @@
 import {expectType, expectAssignable} from 'tsd';
-import {serializeError, deserializeError, ErrorObject, Options} from './index.js';
+import {
+	serializeError, deserializeError, type ErrorObject, type Options,
+} from './index.js';
 
 const error = new Error('unicorn');
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,9 @@
 import {expectType, expectAssignable} from 'tsd';
 import {
-	serializeError, deserializeError, type ErrorObject, type Options,
+	serializeError,
+	deserializeError,
+	type ErrorObject,
+	type Options,
 } from './index.js';
 
 const error = new Error('unicorn');

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"//test": "xo && ava && tsd",
-		"test": "ava && tsd"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"exports": "./index.js",
 	"sideEffects": false,
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"//test": "xo && ava && tsd",
@@ -38,11 +38,11 @@
 		"deserialize"
 	],
 	"dependencies": {
-		"type-fest": "^2.12.2"
+		"type-fest": "^4.31.0"
 	},
 	"devDependencies": {
-		"ava": "^4.2.0",
-		"tsd": "^0.20.0",
-		"xo": "^0.48.0"
+		"ava": "^6.2.0",
+		"tsd": "^0.31.2",
+		"xo": "^0.60.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -11,15 +11,6 @@ function deserializeNonError(t, value) {
 	t.is(deserialized.message, JSON.stringify(value));
 }
 
-// TODO: Replace with plain `new Error('outer', {cause: new Error('inner')})` when targeting Node 16.9+
-function setErrorCause(error, cause) {
-	Object.defineProperty(error, 'cause', {
-		value: cause,
-		enumerable: false,
-		writable: true,
-	});
-}
-
 test('main', t => {
 	const serialized = serializeError(new Error('foo'));
 	const properties = Object.keys(serialized);
@@ -149,9 +140,11 @@ test('should serialize nested errors', t => {
 });
 
 test('should serialize the cause property', t => {
-	const error = new Error('outer error');
-	setErrorCause(error, new Error('inner error'));
-	setErrorCause(error.cause, new Error('deeper error'));
+	const error = new Error('outer error', {
+		cause: new Error('inner error', {
+			cause: new Error('deeper error'),
+		}),
+	});
 
 	const serialized = serializeError(error);
 	t.is(serialized.message, 'outer error');

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test('should drop functions', t => {
 
 	const serialized = serializeError(object);
 	t.deepEqual(serialized, {});
-	t.false(Object.prototype.hasOwnProperty.call(serialized, 'a'));
+	t.false(Object.hasOwn(serialized, 'a'));
 });
 
 test('should not access deep non-enumerable properties', t => {
@@ -467,13 +467,19 @@ test('should serialize properties up to `Options.maxDepth` levels deep', t => {
 	t.deepEqual(levelZero, {});
 
 	const levelOne = serializeError(error, {maxDepth: 1});
-	t.deepEqual(levelOne, {message, name, stack, one: {}});
+	t.deepEqual(levelOne, {
+		message, name, stack, one: {},
+	});
 
 	const levelTwo = serializeError(error, {maxDepth: 2});
-	t.deepEqual(levelTwo, {message, name, stack, one: {two: {}}});
+	t.deepEqual(levelTwo, {
+		message, name, stack, one: {two: {}},
+	});
 
 	const levelThree = serializeError(error, {maxDepth: 3});
-	t.deepEqual(levelThree, {message, name, stack, one: {two: {three: {}}}});
+	t.deepEqual(levelThree, {
+		message, name, stack, one: {two: {three: {}}},
+	});
 });
 
 test('should identify serialized errors', t => {


### PR DESCRIPTION
Lint is failing, package hasn't been updated in a while.

I tried to keep it non-breaking but due to the `getAllComments` bug, there's no working XO version compatible with Node 14+

Before releasing a new major, I'll likely make more changes to this package.