### PR TITLE
Add wrap option for deserialized errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,16 @@ export type Options = {
 	@default true
 	*/
 	readonly useToJSON?: boolean;
+
+	/**
+	Wrap the deserialized error in a new error with the deserialized error set as its `cause`.
+	This captures the current stack while preserving the original deserialized error.
+
+	Only applies to `deserializeError`.
+
+	@default false
+	*/
+	readonly wrap?: boolean;
 };
 
 /**
@@ -121,6 +131,7 @@ Deserialize a plain object or any value into an `Error` object.
 - Enumerable properties are kept enumerable (all properties besides the non-enumerable ones).
 - Circular references are handled.
 - Native error constructors are preserved (TypeError, DOMException, etc) and more can be added.
+- The deserialized error can be wrapped as the `cause` of a new error to capture the current stack.
 
 @example
 ```

--- a/index.js
+++ b/index.js
@@ -53,6 +53,28 @@ const newError = name => {
 		: new ErrorConstructor();
 };
 
+const wrapError = (error, stackStartFunction) => {
+	const wrappedError = newError(error.name);
+
+	for (const property of ['name', 'message', 'cause']) {
+		const value = property === 'cause' ? error : error[property];
+		if (value === undefined || value === null) {
+			continue;
+		}
+
+		Object.defineProperty(wrappedError, property, {
+			value,
+			enumerable: false,
+			configurable: true,
+			writable: true,
+		});
+	}
+
+	Error.captureStackTrace?.(wrappedError, stackStartFunction);
+
+	return wrappedError;
+};
+
 const destroyCircular = ({
 	from,
 	seen,
@@ -205,14 +227,18 @@ export function serializeError(value, options = {}) {
 }
 
 export function deserializeError(value, options = {}) {
-	const {maxDepth = Number.POSITIVE_INFINITY} = options;
+	const {
+		maxDepth = Number.POSITIVE_INFINITY,
+		wrap = false,
+	} = options;
 
 	if (value instanceof Error) {
-		return value;
+		return wrap ? wrapError(value, deserializeError) : value;
 	}
 
+	let deserializedError;
 	if (isMinimumViableSerializedError(value)) {
-		return destroyCircular({
+		deserializedError = destroyCircular({
 			from: value,
 			seen: new Set(),
 			to: newError(value.name),
@@ -220,9 +246,11 @@ export function deserializeError(value, options = {}) {
 			depth: 0,
 			serialize: false,
 		});
+	} else {
+		deserializedError = new NonError(value);
 	}
 
-	return new NonError(value);
+	return wrap ? wrapError(deserializedError, deserializeError) : deserializedError;
 }
 
 export function isErrorLike(value) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,7 +19,8 @@ expectTypeOf(serializeError(null)).toEqualTypeOf<ErrorObject>();
 expectTypeOf(serializeError(() => {})).toEqualTypeOf<ErrorObject>();
 expectTypeOf(serializeError(error as unknown)).toEqualTypeOf<ErrorObject>();
 expectTypeOf(serializeError(error)).toEqualTypeOf<ErrorObject>();
-expectTypeOf({maxDepth: 1}).toMatchTypeOf<Options>();
+expectTypeOf({maxDepth: 1}).toExtend<Options>();
+expectTypeOf({wrap: true}).toExtend<Options>();
 
 expectTypeOf(deserializeError({
 	message: 'error message',
@@ -27,6 +28,9 @@ expectTypeOf(deserializeError({
 	name: 'name',
 	code: 'code',
 })).toEqualTypeOf<Error>();
+expectTypeOf(deserializeError({
+	message: 'error message',
+}, {wrap: true})).toEqualTypeOf<Error>();
 
 addKnownErrorConstructor(Error);
 

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ Deserialize a plain object or any value into an `Error` object.
 - Enumerable properties are kept enumerable (all properties besides the non-enumerable ones).
 - Circular references are handled.
 - [Native error constructors](./error-constructors.js) are preserved (TypeError, DOMException, etc) and [more can be added.](#error-constructors)
+- The deserialized error can be wrapped as the `cause` of a new error to capture the current stack.
 
 ### value
 
@@ -180,6 +181,22 @@ Type: `boolean`\
 Default: `true`
 
 Indicate whether to use a `.toJSON()` method if encountered in the object. This is useful when a custom error implements [its own serialization logic via `.toJSON()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior) but you prefer to not use it.
+
+#### wrap
+
+Type: `boolean`\
+Default: `false`
+
+Wrap the deserialized error in a new error with the deserialized error set as its `cause`. This is useful when you want to throw a deserialized error while keeping a stack trace from the current call site.
+
+```js
+import {deserializeError} from 'serialize-error';
+
+const error = deserializeError(serializedError, {wrap: true});
+
+console.log(error.cause);
+//=> [Error: Original error]
+```
 
 ### isErrorLike(value)
 

--- a/test.js
+++ b/test.js
@@ -510,6 +510,58 @@ test('should deserialize plain object', t => {
 	t.is(deserialized.code, 'code');
 });
 
+test('should wrap deserialized errors as cause with a current stack', t => {
+	const deserialized = deserializeError({
+		name: 'TypeError',
+		message: 'error message',
+		stack: 'serialized stack',
+		code: 'code',
+	}, {wrap: true});
+
+	t.true(deserialized instanceof TypeError);
+	t.is(deserialized.name, 'TypeError');
+	t.is(deserialized.message, 'error message');
+	t.is(deserialized.code, undefined);
+	t.true(deserialized.cause instanceof TypeError);
+	t.is(deserialized.cause.message, 'error message');
+	t.is(deserialized.cause.stack, 'serialized stack');
+	t.is(deserialized.cause.code, 'code');
+	t.false(Object.keys(deserialized).includes('cause'));
+	t.not(deserialized.stack, 'serialized stack');
+	t.regex(deserialized.stack, /test\.js/);
+	t.false(deserialized.stack.includes('wrapError'));
+});
+
+test('should wrap deserialized errors with custom constructors', t => {
+	class WrappedCustomError extends Error {
+		name = 'WrappedCustomError';
+	}
+
+	addKnownErrorConstructor(WrappedCustomError);
+
+	const deserialized = deserializeError({
+		name: 'WrappedCustomError',
+		message: 'custom error message',
+		stack: 'serialized custom stack',
+	}, {wrap: true});
+
+	t.true(deserialized instanceof WrappedCustomError);
+	t.is(deserialized.message, 'custom error message');
+	t.true(deserialized.cause instanceof WrappedCustomError);
+	t.is(deserialized.cause.message, 'custom error message');
+	t.is(deserialized.cause.stack, 'serialized custom stack');
+});
+
+test('should wrap existing Error instances when requested', t => {
+	const error = new RangeError('existing error');
+	const deserialized = deserializeError(error, {wrap: true});
+
+	t.true(deserialized instanceof RangeError);
+	t.is(deserialized.message, 'existing error');
+	t.is(deserialized.cause, error);
+	t.not(deserialized, error);
+});
+
 test('should preserve buffers when deserializing', t => {
 	const buffer = Buffer.from([1, 2, 3]);
 	const deserialized = deserializeError({


### PR DESCRIPTION
Fixes #98

### Summary
- Add a `wrap` option to `deserializeError` that returns a new error with the deserialized error set as `cause`.
- Preserve the resolved error constructor for the wrapper and capture a current stack when `Error.captureStackTrace` is available.
- Document the option and cover runtime and type tests.

### Verification
- `npm test`
- `git diff --check`

### Disclosure
This contribution was prepared with AI assistance and reviewed before submission.